### PR TITLE
correct repo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This is the code that accompanies the **ReactJS Authentication Tutorial** on *Au
 ```bash
 
 # Get the project
-git clone git@github.com:auth0-blog/reactjs-authentication-tutorial.git reactjs-authentication-tutorial
+git clone https://github.com/auth0-blog/reactjs-authentication-tutorial.git reactjs-authentication-tutorial
 
 # Change directory
 cd reactjs-authentication-tutorial


### PR DESCRIPTION
This is what i got when i used this

git clone git@github.com:auth0-blog/reactjs-authentication-tutorial.git reactjs-authentication-tutorial
Cloning into 'reactjs-authentication-tutorial'...
Permission denied (publickey).
fatal: Could not read from remote repository.
Please make sure you have the correct access rights and the repository exists.